### PR TITLE
Fix linter whitespace errors

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
   author: Felix Delattre
   description: Debian installer for essential software packages.
-  company: 
+  company:
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -50,7 +50,7 @@ galaxy_info:
     - buster
     - stretch
 
-  galaxy_tags: 
+  galaxy_tags:
     - essentials
     - basic
     - programs


### PR DESCRIPTION
this MR just fixes a couple trailing whitespace errors, highlighted by the YAML linter.