### PR TITLE
Make packages configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,50 @@ Debian installer for essential software packages.
 
 This is work in progress and it is prefered to collaborate on it. Please communicate over the issue queue. Every pull request is highly appreciated.
 
+Requirements
+------------
+
+None
+
+
+Role Variables
+--------------
+
+```yaml
+essential_packets:
+  - apt-transport-https
+  - ca-certificates
+  - curl
+  - dnsutils
+  - geoip-bin
+  - git
+  - htop
+  - iftop
+  - iotop
+  - locate
+  - nano
+  - ncdu
+  - net-tools
+  - python-pip
+  - python3
+  - python3-pip
+  - rsync
+  - screen
+  - sed
+  - sudo
+  - tmux
+  - tree
+  - vim-nox
+  - wget
+  - whois
+  - zsh
+```
+
+Dependencies
+------------
+
+None
+
 Example Playbook
 ----------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,30 @@
 ---
 # defaults file for ansible-role-essentials
+
+essential_packets:
+  - apt-transport-https
+  - ca-certificates
+  - curl
+  - dnsutils
+  - geoip-bin
+  - git
+  - htop
+  - iftop
+  - iotop
+  - locate
+  - nano
+  - ncdu
+  - net-tools
+  - python-pip
+  - python3
+  - python3-pip
+  - rsync
+  - screen
+  - sed
+  - sudo
+  - tmux
+  - tree
+  - vim-nox
+  - wget
+  - whois
+  - zsh

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,29 +22,4 @@
 
 - name: "Install essential software"
   apt: name={{ item }} state=latest
-  with_items:
-    - apt-transport-https
-    - ca-certificates
-    - curl
-    - dnsutils
-    - git
-    - htop
-    - iftop
-    - iotop
-    - locate
-    - nano
-    - ncdu
-    - net-tools
-    - geoip-bin
-    - python-pip
-    - python3
-    - python3-pip
-    - rsync
-    - screen
-    - sed
-    - sudo
-    - tmux
-    - tree
-    - wget
-    - whois
-
+  with_items: "{{ essential_packets }}"


### PR DESCRIPTION
this MR makes the package list configurable by adding the `essential_packets` variable in the defaults.

This results in the package sets being configurable on a per-group basis (in `group_vars`), or even on a per-host basis (in `host_vars`).

Feel free to edit the list of packages, IMHO it should be as minimal as possible to avoid bloated setups.